### PR TITLE
Used 'GenServer.cast()' to handle 'stop' message instead of 'GenServe…

### DIFF
--- a/src/lib/generators/elixir_server_generator.ex.erb
+++ b/src/lib/generators/elixir_server_generator.ex.erb
@@ -73,12 +73,16 @@ defmodule <%= node.namespace %>.<%= node.elixir_connection %> do
   end
 
   def stop(pid) do
-    GenServer.stop(pid)
+    GenServer.cast(pid, :stop)
   end
 
   def init({socket, transport, handler}) do
     {:ok, state} = handler.open_connection(self(), socket)
     {:ok, {socket, transport, handler, state}}
+  end
+
+  def handle_cast(:stop, state) do
+    {:stop, :normal, state}
   end
 
   def handle_cast({:handle_data, data}, {socket, transport, handler, state}) do


### PR DESCRIPTION
Used 'GenServer.cast()' to handle 'stop' message instead of 'GenServer.stop()'.